### PR TITLE
[Fix] Grammatical mistake in build.md file.

### DIFF
--- a/packages/docs/site/docs/main/about/build.md
+++ b/packages/docs/site/docs/main/about/build.md
@@ -44,7 +44,7 @@ This feature is only available for Google Chrome for now. It won't work with oth
 
 Regarding changes done on both sides of the connection:
 
--   Files changed in Playground will be synchronized to on your computer.
+-   Files changed in Playground will be synchronized to your computer.
 -   Files changed on your computer will not be synchronized to Playground. You'll need to click the "Sync local files" button.
 
 With this workflow you can create directly GitHub PRs from your changes done on your local directory.


### PR DESCRIPTION

![Typo](https://github.com/user-attachments/assets/91011f3c-a033-4287-aa2b-df8a651591d1)
---------------------------------------------------------------------------------------------------------
### Issue
On [Build | WordPress Playground](https://wordpress.github.io/wordpress-playground/about/build/)

There is a grammatical mistake "to on" -

"Files changed in Playground will be synchronized **to on** your computer."

### Fix
Fixed: "Files changed in Playground will be synchronized **to** your computer."
